### PR TITLE
docs: improve installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,11 @@ General information about setting up Exif Looter locally
 ## Installation
 
 ```bash
-go get github.com/aydinnyunus/exifLooter
+go install github.com/aydinnyunus/exifLooter@latest
 ```
+
+Exif Looter depends on [exiftool](https://exiftool.org/), so make sure it is on
+your PATH.
 
 <!-- USAGE EXAMPLES -->
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module exifLooter
+module github.com/aydinnyunus/exifLooter
 
 go 1.17
 


### PR DESCRIPTION
#### What has been done?

- Recommend to use `go install` instead of `go get`, and rename the module so that it actually works.
- Mention that `exiftool` is a dependency.
